### PR TITLE
社團幹部RWD，且圖片與文字置中排列

### DIFF
--- a/docs/.vitepress/components/ClubWorker.vue
+++ b/docs/.vitepress/components/ClubWorker.vue
@@ -1,51 +1,83 @@
 <template>
-    <div>
-      <div v-for="group in groups" :key="group.groupName" class="group">
-        <h2>{{ group.groupName }}</h2>
-        <div class="members">
-          <div class="member" v-for="member in group.members" :key="member.name">
-            <img :src="member.image" alt="member.name" class="member-image">
-            <h3>{{ member.name }}</h3>
-            <h4>{{ member.position }}</h4>
-            <p>{{ member.description }}</p>
-          </div>
+  <div>
+    <div v-for="group in groups" :key="group.groupName" class="group">
+      <h2>{{ group.groupName }}</h2>
+      <div class="members">
+        <div class="member" v-for="member in group.members" :key="member.name">
+          <img :src="member.image" alt="member.name" class="member-image">
+          <h3>{{ member.name }}</h3>
+          <h4>{{ member.position }}</h4>
+          <p>{{ member.description }}</p>
         </div>
       </div>
     </div>
-  </template>
-  
-  <script>
-  import leadersData from '../src/json/workers.json';
-  
-  export default {
-    data() {
-      return {
-        groups: leadersData.groups,
-      };
-    },
-  }
-  </script>
-  
-  <style scoped>
-  .group {
-    margin-bottom: 20px;
-  }
-  
-  .members {
-    display: flex;
-    flex-wrap: wrap;
-  }
-  
+  </div>
+</template>
+
+<script>
+import leadersData from '../src/json/workers.json';
+
+export default {
+  data() {
+    return {
+      groups: leadersData.groups,
+    };
+  },
+}
+</script>
+
+<style scoped>
+.group {
+  margin-bottom: 20px;
+}
+
+.members {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.member {
+  flex: 0 1 calc(20% - 10px); /* 每行五個成員 */
+  margin: 10px;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center; /* 垂直居中 */
+}
+
+.member img {
+  margin-bottom: 10px; /* 確保圖片和文字有間距 */
+}
+
+.member-image {
+  width: 100pt;
+  height: 100pt;
+  border-radius: 50%;
+}
+
+/* 響應式設計 */
+@media (max-width: 1200px) {
   .member {
-    flex: 0 1 calc(20% - 10px); /* 每行五個成員 */
-    margin: 30px;
-    text-align: center;
+    flex: 0 1 calc(25% - 10px); /* 每行四個成員 */
   }
-  
-  .member-image {
-    width: 100pt;
-    height: 100pt;
-    border-radius: 50%;
+}
+
+@media (max-width: 992px) {
+  .member {
+    flex: 0 1 calc(33.33% - 10px); /* 每行三個成員 */
   }
-  </style>
-  
+}
+
+@media (max-width: 768px) {
+  .member {
+    flex: 0 1 calc(50% - 10px); /* 每行兩個成員 */
+  }
+}
+
+@media (max-width: 576px) {
+  .member {
+    flex: 0 1 calc(100% - 10px); /* 每行一個成員 */
+  }
+}
+</style>

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -1,4 +1,5 @@
 import { defineConfig } from 'vitepress'
+import ClubLeader from 'docs\.vitepress\components\ClubWorker.vue';
 
 // https://vitepress.dev/reference/site-config
 export default defineConfig({

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "mitc_web",
+  "name": "MITC-Web-vitepress",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {


### PR DESCRIPTION
以常見的響應式設計斷點：
超小屏幕（手機縱向，寬度 < 576px）
小屏幕（手機橫向，寬度 ≥ 576px）
中等屏幕（平板，寬度 ≥ 768px）
大屏幕（桌面，寬度 ≥ 992px）
超大屏幕（大型桌面，寬度 ≥ 1200px）
分好後，
因圖片與下方介紹沒對齊，進行下述調整：
display: flex 和 flex-direction: column：將每個 .member 設置為彈性容器，並垂直排列其中的項目。
align-items: center：使圖片和文字在垂直方向上居中對齊。
margin-bottom：在圖片和文字之間添加一些間距，確保排版更美觀。